### PR TITLE
Add latest tag when publishing to Docker Hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BASETAG=bitjourney/elasticsearch-ci
 TIMESTAMP=`date "+%Y%m%d%H%M"`
 IMAGETAG=$(BASETAG):$(TIMESTAMP)
+LATESTTAG=$(BASETAG):latest
 
 publish: push-to-docker-hub create-git-tag
 
@@ -9,6 +10,8 @@ push-to-docker-hub:
 		docker login	
 		docker build -t $(IMAGETAG) image/
 		docker push $(IMAGETAG)
+		docker build -t $(LATESTTAG) image/
+		docker push $(LATESTTAG)
 
 create-git-tag:
 		git tag $(TIMESTAMP)


### PR DESCRIPTION
`bitjourney/elasticsearch-ci:latest` のように、常に最新のタグを利用できるように、`latest` タグでも Docker Imageを公開します。

これがないと、タイムスタンプのタグしか存在しないことになってしまい、非常に使い勝手が悪いからです。

@bitjourney/developers 
レビューお願いします。