### PR TITLE
[WIP] Setting of memory lock for prevent memory swap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,23 +75,8 @@ jobs:
 
       - deploy:
           name: Publish to Docker Hub
-          environment:
-            BASE_TAG: bitjourney/elasticsearch-ci
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              TIMESTAMP=`date "+%Y%m%d%H%M"`
-              IMAGE_TAG_DEPLOY="$BASE_TAG:$TIMESTAMP"
-              LATEST_TAG="$BASE_TAG:latest"
-
-              docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWORD
-
-              docker build -t $IMAGE_TAG_DEPLOY image/
-              docker push $IMAGE_TAG_DEPLOY
-
-              docker build -t $LATEST_TAG image/
-              docker push $LATEST_TAG
-
-              git tag $TIMESTAMP
-              git push --tags
+              make publish
             fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
-BASETAG=bitjourney/elasticsearch-ci
-TIMESTAMP=`date "+%Y%m%d%H%M"`
-IMAGETAG=$(BASETAG):$(TIMESTAMP)
-LATESTTAG=$(BASETAG):latest
+BASE_TAG:=bitjourney/elasticsearch-ci
+TIMESTAMP:=`date "+%Y%m%d%H%M"`
+IMAGE_TAG:=$(BASE_TAG):$(TIMESTAMP)
+LATEST_TAG:=$(BASE_TAG):latest
 
 publish: push-to-docker-hub create-git-tag
 
 push-to-docker-hub:
 		docker --version
 		docker login	
-		docker build -t $(IMAGETAG) image/
-		docker push $(IMAGETAG)
-		docker build -t $(LATESTTAG) image/
-		docker push $(LATESTTAG)
+		docker build -t $(IMAGE_TAG) image/
+		docker push $(IMAGE_TAG)
+		docker build -t $(LATEST_TAG) image/
+		docker push $(LATEST_TAG)
 
 create-git-tag:
 		git tag $(TIMESTAMP)

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -4,6 +4,7 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:5.1.2
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
+ADD limits.conf /etc/security/
 
 USER root
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml

--- a/image/elasticsearch.yml
+++ b/image/elasticsearch.yml
@@ -16,3 +16,6 @@ xpack.security.enabled: false
 indices.fielddata.cache.size: 40%
 # Checks to see whether the query size is too large before data is loaded
 indices.breaker.fielddata.limit: 50%
+
+# Disable swap memory
+bootstrap.memory_lock: true

--- a/image/limits.conf
+++ b/image/limits.conf
@@ -1,0 +1,3 @@
+# allow user 'elasticsearch' mlockall
+elasticsearch soft memlock unlimited
+elasticsearch hard memlock unlimited


### PR DESCRIPTION
When memory swap occurs, processing slows down, and load is high.
So, should memory lock for prevent memory swap.

I referred the setting here.
see: https://www.elastic.co/guide/en/elasticsearch/reference/5.4/setup-configuration-memory.html