### PR TITLE
Elasticsearch 6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
       - run:
           name: Install Docker client
           environment:
-            DOCKER_VERSION: "17.05.0-ce"
+            DOCKER_VERSION: "17.09.1-ce"
           command: |
-            curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION.tgz
+            curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz
             tar -xz -C /tmp -f /tmp/docker-$DOCKER_VERSION.tgz
             mv /tmp/docker/* /usr/bin
 
@@ -78,7 +78,6 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWORD
-
               make publish
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: Build a docker image from Dockerfile
-          command: make check
+          command: make check TEST_IMAGE_TAG=$TEST_IMAGE_TAG
 
       - run:
           name: Run a container from the image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Health Check if the Elasticsearch container is working
           environment:
-            HEALTH_CHECK_RETRY_LIMIT: 20
+            HEALTH_CHECK_RETRY_LIMIT: 40
             HEALTH_CHECK_RETRY_DELAY: 3
             HEALTH_CHECK_PORT: 9200
           command: |
@@ -71,7 +71,7 @@ jobs:
             docker run --network container:$CONTAINER_NAME \
               appropriate/curl --retry $HEALTH_CHECK_RETRY_LIMIT \
                                --retry-delay $HEALTH_CHECK_RETRY_DELAY \
-                               --retry-connrefused http://localhost:$HEALTH_CHECK_PORT
+                               --retry-connrefused http://127.0.0.1:$HEALTH_CHECK_PORT
 
       - deploy:
           name: Publish to Docker Hub

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ VERSION:=`perl -le 'local $$/; print <> =~ /FROM.*?(\d+(?:\.\d+)*)/' < image/Doc
 DOCKER_TAG=$(BASE_TAG):$(VERSION)
 GIT_TAG=$(VERSION)-$(TIMESTAMP)
 
-TEST_IMAGE_TAG:=test
+TEST_IMAGE_TAG:=elasticsearch-docker-test
 
 check:
 	@echo DOCKER_TAG=$(DOCKER_TAG)
 	@echo GIT_TAG=$(GIT_TAG)
 	docker --version
 	docker build -t $(TEST_IMAGE_TAG) image/
+	docker run -t $(TEST_IMAGE_TAG) elasticsearch --version
 
 publish:
 	docker --version

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,14 +1,24 @@
+# see https://github.com/elastic/elasticsearch-docker for details
+
 # The version must be fixed to the latest of the Amazon Elasticsearch Service
 # https://aws.amazon.com/elasticsearch-service/faqs/
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.3
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.3
 
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 
 USER root
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
-RUN elasticsearch-plugin install analysis-kuromoji
+# install the same plugins as AES
+# https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
+RUN \
+    elasticsearch-plugin remove --purge x-pack \
+  ; elasticsearch-plugin install --batch ingest-attachment \
+  ; elasticsearch-plugin install --batch analysis-icu \
+  ; elasticsearch-plugin install --batch analysis-kuromoji
 
 # elasticsearch cannot be executed by 'root' user for security reasons
 # Details: https://discuss.elastic.co/t/why-is-it-elasticsearch-is-not-allowed-to-run-as-root/60413
 USER elasticsearch
+
+CMD [ "elasticsearch" ]

--- a/image/elasticsearch.yml
+++ b/image/elasticsearch.yml
@@ -1,18 +1,23 @@
-cluster.name: "docker-ci-cluster"
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
 
 # minimum_master_nodes need to be explicitly set when bound on a public IP
 # set to 1 to allow single node clusters
-# because a single node is enough for CI build
 # Details: https://github.com/elastic/elasticsearch/pull/17288
 discovery.zen.minimum_master_nodes: 1
-
-# Disable X-Packs Security
-# because it requires BASE authentication which is redundant for test
-# Details: https://www.elastic.co/guide/en/x-pack/current/security-settings.html#general-security-settings
-xpack.security.enabled: false
 
 # https://www.elastic.co/guide/en/elasticsearch/guide/current/_limiting_memory_usage.html#fielddata-size
 # Place an upper limit to the fielddata cache to avoid OOM
 indices.fielddata.cache.size: 40%
 # Checks to see whether the query size is too large before data is loaded
 indices.breaker.fielddata.limit: 50%
+
+# CORS
+http.port: 9200
+http.cors.allow-origin: "http://localhost:*"
+http.cors.enabled: true
+http.cors.allow-headers : X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
+http.cors.allow-credentials: true
+
+# logging
+logger.deprecation.level: warn

--- a/image/elasticsearch.yml
+++ b/image/elasticsearch.yml
@@ -1,5 +1,4 @@
 cluster.name: "docker-cluster"
-network.host: 0.0.0.0
 
 # minimum_master_nodes need to be explicitly set when bound on a public IP
 # set to 1 to allow single node clusters


### PR DESCRIPTION
Upgrade elasticsearch to 6.2.3 with some extra settings.

* install extra plugins
* enable deprecation logging
* enable CORS for, e.g., https://github.com/appbaseio/dejavu